### PR TITLE
fix: replacing URI#escape

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -230,7 +230,7 @@ module ResqueCleaner
         f: @from,
         t: @to,
         regex: @regex
-      }.map {|key,value| "#{key}=#{URI.encode(value.to_s)}"}.join("&")
+      }.map {|key,value| "#{key}=#{URI::DEFAULT_PARSER.encode(value.to_s)}"}.join("&")
 
       @list_url = "cleaner_list?#{params}"
       @dump_url = "cleaner_dump?#{params}"

--- a/lib/resque_cleaner/server/views/_stats.erb
+++ b/lib/resque_cleaner/server/views/_stats.erb
@@ -10,7 +10,7 @@
   </tr>
   <% @stats[type.to_sym].each do |field,count| %>
     <tr>
-      <% filter = "#{q}=#{URI.encode(field)}" %>
+      <% filter = "#{q}=#{URI::DEFAULT_PARSER.encode(field)}" %>
       <td><%= field %></td>
       <td class="number">
         <a href="cleaner_list?<%=filter%>"><%= count[:total] %></a>


### PR DESCRIPTION
# Description
To keep resque cleaner working on Ruby 3 we need to remove `URI#escape` that was removed in Ruby 3.0

## Test plan
Open `/resque/cleaner`